### PR TITLE
feat: add configurable bash timeouts to ClaudeCodeExecutor

### DIFF
--- a/src/clients/claude-executor.ts
+++ b/src/clients/claude-executor.ts
@@ -40,9 +40,9 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
   private allowedTools: string[];
   private disallowedTools: string[];
   private dangerouslySkipPermissions: boolean;
-  private timeout: number = 300000; // Default timeout of 5 minutes
-  private bashDefaultTimeoutMs: number = 300000; // Default BASH_DEFAULT_TIMEOUT_MS of 5 minutes
-  private bashMaxTimeoutMs: number = 600000; // Default BASH_MAX_TIMEOUT_MS of 10 minutes
+  private timeout: number = 300000;
+  private bashDefaultTimeoutMs: number = 300000;
+  private bashMaxTimeoutMs: number = 600000;
   public rateLimitRetryDelay: number | undefined;
 
   constructor(config: ClaudeExecutorConfig = {}) {

--- a/src/clients/claude-executor.ts
+++ b/src/clients/claude-executor.ts
@@ -27,6 +27,9 @@ export interface ClaudeExecutorConfig {
   disallowedTools?: string[];
   dangerouslySkipPermissions?: boolean;
   rateLimitRetryDelay?: number; // Rate limit retry delay in milliseconds
+  timeout?: number; // Execution timeout in milliseconds
+  bashDefaultTimeoutMs?: number; // BASH_DEFAULT_TIMEOUT_MS environment variable
+  bashMaxTimeoutMs?: number; // BASH_MAX_TIMEOUT_MS environment variable
 }
 
 /**
@@ -37,7 +40,9 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
   private allowedTools: string[];
   private disallowedTools: string[];
   private dangerouslySkipPermissions: boolean;
-  // Exposed for test visibility only; dispatcher performs the waiting
+  private timeout: number = 300000; // Default timeout of 5 minutes
+  private bashDefaultTimeoutMs: number = 300000; // Default BASH_DEFAULT_TIMEOUT_MS of 5 minutes
+  private bashMaxTimeoutMs: number = 600000; // Default BASH_MAX_TIMEOUT_MS of 10 minutes
   public rateLimitRetryDelay: number | undefined;
 
   constructor(config: ClaudeExecutorConfig = {}) {
@@ -47,6 +52,16 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
     this.dangerouslySkipPermissions =
       config.dangerouslySkipPermissions || false;
     this.rateLimitRetryDelay = config.rateLimitRetryDelay;
+    
+    if (config.bashDefaultTimeoutMs !== undefined) {
+      this.bashDefaultTimeoutMs = config.bashDefaultTimeoutMs;
+    }
+    if (config.bashMaxTimeoutMs !== undefined) {
+      this.bashMaxTimeoutMs = config.bashMaxTimeoutMs;
+    }
+    if (config.timeout !== undefined) {
+      this.timeout = config.timeout;
+    }
   }
 
   /**
@@ -59,12 +74,14 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
 
       const command = this.buildClaudeCommand();
       const { execSync } = await import('child_process');
+      const env = this.buildEnvironment();
       const output = execSync(command, {
         cwd: this.workingDirectory,
         input: prompt,
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'inherit'],
-        timeout: 300000,
+        timeout: this.timeout,
+        env,
       });
 
       logger.info(`ClaudeCode response: ${output.substring(0, 200)}...`);
@@ -119,6 +136,24 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
     }
 
     return command;
+  }
+
+  /**
+   * Builds the environment variables for Claude Code execution
+   * @returns Environment variables object
+   */
+  private buildEnvironment(): NodeJS.ProcessEnv {
+    const env = { ...process.env };
+
+    if (this.bashDefaultTimeoutMs) {
+      env.BASH_DEFAULT_TIMEOUT_MS = this.bashDefaultTimeoutMs.toString();
+    }
+
+    if (this.bashMaxTimeoutMs) {
+      env.BASH_MAX_TIMEOUT_MS = this.bashMaxTimeoutMs.toString();
+    }
+
+    return env;
   }
 
   /**

--- a/tests/claude-executor.test.ts
+++ b/tests/claude-executor.test.ts
@@ -87,6 +87,25 @@ describe('ClaudeCodeExecutor', () => {
       const hooks = executor as unknown as ExecutorTestHooks;
       expect(hooks.rateLimitRetryDelay).toBe(10 * 60 * 1000);
     });
+
+    test('should accept timeout configuration', () => {
+      const executor = new ClaudeCodeExecutor({
+        timeout: 600000,
+        bashDefaultTimeoutMs: 400000,
+        bashMaxTimeoutMs: 800000,
+      });
+      
+      // Access private properties for testing
+      const privateExecutor = executor as unknown as {
+        timeout: number;
+        bashDefaultTimeoutMs: number;
+        bashMaxTimeoutMs: number;
+      };
+      
+      expect(privateExecutor.timeout).toBe(600000);
+      expect(privateExecutor.bashDefaultTimeoutMs).toBe(400000);
+      expect(privateExecutor.bashMaxTimeoutMs).toBe(800000);
+    });
   });
 
   describe('execution', () => {
@@ -110,6 +129,11 @@ describe('ClaudeCodeExecutor', () => {
           encoding: 'utf8',
           stdio: ['pipe', 'pipe', 'inherit'],
           timeout: 300000,
+          env: expect.objectContaining({
+            BASH_DEFAULT_TIMEOUT_MS: '300000',
+            BASH_MAX_TIMEOUT_MS: '600000',
+            ...process.env,
+          }),
         }
       );
     });


### PR DESCRIPTION
## Summary
- Add `bashDefaultTimeoutMs` and `bashMaxTimeoutMs` configuration options to ClaudeCodeExecutor
- Pass `BASH_DEFAULT_TIMEOUT_MS` and `BASH_MAX_TIMEOUT_MS` environment variables to claude code command
- Update unit tests to verify timeout configuration and environment variables

## Test plan
- [x] Run existing ClaudeCodeExecutor tests
- [x] Verify new timeout configuration options work correctly
- [x] Ensure environment variables are passed to claude code command
- [x] Confirm backward compatibility with default timeout values

🤖 Generated with [Claude Code](https://claude.ai/code)