### PR TITLE
refactor(git): discard uncommitted changes during branch cleanup

### DIFF
--- a/src/infrastructure/git-repository.ts
+++ b/src/infrastructure/git-repository.ts
@@ -10,6 +10,7 @@ export interface IGitRepository {
   checkForChanges(): Promise<boolean>;
   generateBranchName(issue: GitHubIssue): string;
   deleteBranch(branchName: string, baseBranch: string): void;
+  discardChanges(): void;
 }
 
 /**
@@ -108,6 +109,26 @@ export class GitRepository implements IGitRepository {
     } catch (error) {
       logger.warn(`Failed to cleanup branch ${branchName}:`, error);
       // Don't throw error as branch cleanup is not critical
+    }
+  }
+
+  /**
+   * Discards all uncommitted changes in the working directory
+   */
+  discardChanges(): void {
+    try {
+      execSync('git restore .', { 
+        cwd: this.workingDirectory, 
+        stdio: 'pipe' 
+      });
+      execSync('git clean -fd', {
+        cwd: this.workingDirectory, 
+        stdio: 'pipe' 
+      });
+      logger.info('Discarded all uncommitted changes');
+    } catch (error) {
+      logger.warn('Failed to discard changes:', error);
+      // Don't throw error as discarding changes is not critical
     }
   }
 }

--- a/src/services/issue-processor.ts
+++ b/src/services/issue-processor.ts
@@ -105,6 +105,7 @@ export class IssueProcessor {
   private cleanupBranch(branchName: string, baseBranch: string, reason: string): void {
     try {
       logger.info(`Cleaning up branch ${branchName} due to ${reason}`);
+      this.gitRepository.discardChanges();
       this.gitRepository.deleteBranch(branchName, baseBranch);
     } catch (cleanupError) {
       logger.warn(`Failed to cleanup branch ${branchName}:`, cleanupError);

--- a/tests/git-repository.test.ts
+++ b/tests/git-repository.test.ts
@@ -122,4 +122,40 @@ describe('GitRepository', () => {
       expect(hasChanges).toBe(false);
     });
   });
+
+  describe('deleteBranch', () => {
+    test('should switch to base branch and delete target branch', () => {
+      mockExecSync.mockReturnValue('');
+
+      gitRepository.deleteBranch('test-branch', 'main');
+
+      expect(mockExecSync).toHaveBeenNthCalledWith(1, 'git checkout main', {
+        cwd: '/test/workspace',
+        stdio: 'pipe',
+      });
+
+      expect(mockExecSync).toHaveBeenNthCalledWith(2, 'git branch -D test-branch', {
+        cwd: '/test/workspace',
+        stdio: 'pipe',
+      });
+    });
+  });
+
+  describe('discardChanges', () => {
+    test('should reset and clean uncommitted changes', () => {
+      mockExecSync.mockReturnValue('');
+
+      gitRepository.discardChanges();
+
+      expect(mockExecSync).toHaveBeenNthCalledWith(1, 'git restore .', {
+        cwd: '/test/workspace',
+        stdio: 'pipe',
+      });
+
+      expect(mockExecSync).toHaveBeenNthCalledWith(2, 'git clean -fd', {
+        cwd: '/test/workspace',
+        stdio: 'pipe',
+      });
+    });
+  });
 });

--- a/tests/issue-processor.test.ts
+++ b/tests/issue-processor.test.ts
@@ -33,6 +33,7 @@ describe('IssueProcessor', () => {
       switchToBranch: jest.fn(),
       checkForChanges: jest.fn(),
       deleteBranch: jest.fn(),
+      discardChanges: jest.fn(),
     };
 
     mockClaudeExecutor = {
@@ -148,6 +149,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('No changes were made by ClaudeCode');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
@@ -159,6 +161,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Git error');
+      expect(mockGitRepository.discardChanges).not.toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).not.toHaveBeenCalled();
     });
 
@@ -173,6 +176,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Claude execution failed');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
@@ -189,6 +193,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Claude execution failed');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
       // Should still return the original error, not the cleanup error
     });
@@ -208,6 +213,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Commit failed');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
@@ -228,6 +234,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('PR creation failed');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
@@ -255,6 +262,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Implementation failed');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
@@ -266,6 +274,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Branch creation failed');
+      expect(mockGitRepository.discardChanges).not.toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).not.toHaveBeenCalled();
     });
 
@@ -282,6 +291,7 @@ describe('IssueProcessor', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Original error');
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
   });


### PR DESCRIPTION
## This refactor introduces a safer branch cleanup flow

### Changes
- **feat(repo):** add `GitRepository.discardChanges()` to restore and clean working tree  
- **refactor(issue-processor):** call `discardChanges()` before deleting branches on failure/no-op  
- **test:** add/adjust tests for `deleteBranch` and `discardChanges` flows  

### Why
- Prevents lingering untracked/modified files from contaminating subsequent runs  
- Makes cleanup idempotent and less error-prone  

### Notes
- Command errors during cleanup are logged and non-fatal  
- Covered by unit tests (all pass)  