### PR TITLE
refactor(issue-processor): cleanup branch on failure before rethrowing RateLimitError

### DIFF
--- a/src/services/issue-processor.ts
+++ b/src/services/issue-processor.ts
@@ -78,14 +78,14 @@ export class IssueProcessor {
       };
       
     } catch (error) {
-      // Let RateLimitError bubble up to be handled by dispatcher
-      if (error instanceof RateLimitError) {
-        throw error;
-      }
-      
       // Only cleanup branch if it was created and Claude Code execution failed
       if (branchCreated) {
         this.cleanupBranch(branchName, baseBranch, 'Claude Code execution failure');
+      }
+      
+      // Let RateLimitError bubble up to be handled by dispatcher
+      if (error instanceof RateLimitError) {
+        throw error;
       }
       
       logger.error(`Failed to process issue #${issue.number}:`, error);

--- a/tests/issue-processor.test.ts
+++ b/tests/issue-processor.test.ts
@@ -238,7 +238,7 @@ describe('IssueProcessor', () => {
       expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
 
-    test('should not cleanup branch when RateLimitError occurs after branch creation', async () => {
+    test('should cleanup branch when RateLimitError occurs after branch creation', async () => {
       const rateLimitError = new RateLimitError('Rate limit exceeded');
       mockGitRepository.generateBranchName.mockReturnValue('issue-123-test-issue');
       mockGitRepository.switchToBranch.mockResolvedValue();
@@ -246,7 +246,8 @@ describe('IssueProcessor', () => {
       mockClaudeExecutor.execute.mockRejectedValue(rateLimitError);
 
       await expect(issueProcessor.processIssue(mockIssue, 'main')).rejects.toThrow(RateLimitError);
-      expect(mockGitRepository.deleteBranch).not.toHaveBeenCalled();
+      expect(mockGitRepository.discardChanges).toHaveBeenCalled();
+      expect(mockGitRepository.deleteBranch).toHaveBeenCalledWith('issue-123-test-issue', 'main');
     });
   });
 


### PR DESCRIPTION
Behavioral change:\n- Clean up working branch even when Claude execution fails with RateLimitError, then rethrow for upstream handling.\n\nRationale:\n- Prevents stray branches and dirty worktrees when runs are aborted due to rate limits.\n\nTests:\n- Updated tests to assert cleanup is executed on RateLimitError after branch creation.\n- Full suite passes locally.