### PR TITLE
feat: implement log rotation with 1-week retention policy (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,32 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed development setup, coding st
 
 ## Logging
 
-The dispatcher creates comprehensive logs:
+The dispatcher creates comprehensive logs with automatic rotation:
 
-- `combined.log`: All log messages
-- `error.log`: Error messages only
-- Console output with colored formatting
+- **Log files**: Daily rotated files in `logs/` directory
+  - `logs/combined-YYYY-MM-DD.log`: All log messages  
+  - `logs/error-YYYY-MM-DD.log`: Error messages only
+- **Console output**: Colored formatting for real-time monitoring
+- **Retention**: 1-week retention policy with automatic cleanup
+- **Compression**: Old log files are automatically compressed
+
+### Log Configuration
+
+Configure log rotation via environment variables:
+
+| Variable              | Default | Description                              |
+| --------------------- | ------- | ---------------------------------------- |
+| `LOG_MAX_SIZE`        | `20m`   | Maximum size per log file               |
+| `LOG_RETENTION_DAYS`  | `7d`    | Number of days to keep logs             |
+| `LOG_DIRECTORY`       | `logs`  | Directory for log files                 |
+
+Example:
+```bash
+export LOG_MAX_SIZE=50m
+export LOG_RETENTION_DAYS=14d
+export LOG_DIRECTORY=/var/log/claude-dispatcher
+claude-code-dispatcher start ...
+```
 
 ## Error Handling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "claude-code-dispatcher",
-  "version": "1.0.0",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-dispatcher",
-      "version": "1.0.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.0.0",
-        "winston": "^3.10.0"
+        "winston": "^3.10.0",
+        "winston-daily-rotate-file": "^5.0.0"
       },
       "bin": {
-        "claude-code-dispatcher": "dist/cli.js"
+        "claude-code-dispatcher": "bin/claude-code-dispatcher"
       },
       "devDependencies": {
         "@types/jest": "^29.0.0",
@@ -27,7 +28,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2835,6 +2836,15 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4261,6 +4271,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4316,6 +4335,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/once": {
@@ -5507,6 +5535,24 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "commander": "^11.0.0",
-    "winston": "^3.10.0"
+    "winston": "^3.10.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.0.0",


### PR DESCRIPTION
## Summary
- Implement log rotation functionality with 1-week retention policy
- Add automatic cleanup of old log files to prevent disk space issues
- Ensure logs are properly rotated and archived

## Test plan
- [ ] Verify log rotation works correctly
- [ ] Confirm old logs are deleted after 1 week
- [ ] Test that current logging functionality remains unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)