### PR TITLE
feat: increase default timeout values for better stability

### DIFF
--- a/src/clients/claude-executor.ts
+++ b/src/clients/claude-executor.ts
@@ -40,9 +40,9 @@ export class ClaudeCodeExecutor implements IClaudeCodeExecutor {
   private allowedTools: string[];
   private disallowedTools: string[];
   private dangerouslySkipPermissions: boolean;
-  private timeout: number = 300000;
-  private bashDefaultTimeoutMs: number = 300000;
-  private bashMaxTimeoutMs: number = 600000;
+  private timeout: number = 600000;
+  private bashDefaultTimeoutMs: number = 600000;
+  private bashMaxTimeoutMs: number = 1200000;
   public rateLimitRetryDelay: number | undefined;
 
   constructor(config: ClaudeExecutorConfig = {}) {

--- a/tests/claude-executor.test.ts
+++ b/tests/claude-executor.test.ts
@@ -128,10 +128,10 @@ describe('ClaudeCodeExecutor', () => {
           input: 'Test prompt',
           encoding: 'utf8',
           stdio: ['pipe', 'pipe', 'inherit'],
-          timeout: 300000,
+          timeout: 600000,
           env: expect.objectContaining({
-            BASH_DEFAULT_TIMEOUT_MS: '300000',
-            BASH_MAX_TIMEOUT_MS: '600000',
+            BASH_DEFAULT_TIMEOUT_MS: '600000',
+            BASH_MAX_TIMEOUT_MS: '1200000',
             ...process.env,
           }),
         }


### PR DESCRIPTION
## Summary
- Increase default timeout values in ClaudeCodeExecutor for better handling of long-running operations
- Update test expectations to match new timeout values

## Changes Made

### ClaudeCodeExecutor Default Values
- **timeout**: `300000ms` → `600000ms` (5min → 10min)
- **bashDefaultTimeoutMs**: `300000ms` → `600000ms` (5min → 10min)  
- **bashMaxTimeoutMs**: `600000ms` → `1200000ms` (10min → 20min)

### Test Updates
- Updated test expectations in `claude-executor.test.ts` to verify new timeout values
- Environment variable expectations updated to match new defaults

## Rationale

The previous 5-minute timeout was sometimes insufficient for:
- Complex code generation tasks
- Large repository operations
- Network-dependent operations (git push, PR creation)
- Claude Code processing of substantial changes

**Benefits:**
✅ Reduced timeout-related failures  
✅ Better handling of complex tasks  
✅ More reliable long-running operations  
✅ Configurable via constructor parameters (backward compatible)  

## Backward Compatibility

This change is **fully backward compatible**:
- Existing configurations with explicit timeout values are unchanged
- Only affects default values when no configuration is provided
- Public API remains the same

## Test Plan
- [x] All existing tests pass with updated expectations
- [x] Verify timeout values are correctly set in ClaudeCodeExecutor
- [x] Confirm environment variables are passed correctly
- [x] Validate no performance regression

## Impact Assessment

**Low Risk Change:**
- Only affects default values, no logic changes
- Timeout increase improves reliability rather than breaking functionality
- Extensive test coverage ensures correctness

🤖 Generated with [Claude Code](https://claude.ai/code)